### PR TITLE
Update devcontainer.json for docker-in-docker

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,9 @@
 		}
 	  },
 	// Features to add to the dev container. More info: https://containers.dev/features.
-	// "features": {},
+	"features": {
+        "ghcr.io/devcontainers/features/docker-in-docker:latest": {}
+	},
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
@@ -24,7 +26,7 @@
 		"codespaces": {
 			"openFiles": [
 			  "workshop/README.md",
-			  "workshop/main.py",
+			  "workshop/main.py"
 			]
 		},
 		"vscode": {


### PR DESCRIPTION
Currently `devcontainer.json` has the default container image settings that lacks the docker-in-docker feature for adding container-based MCP servers. This PR is to add that feature.